### PR TITLE
Fix: 게시글 작성 시 영상이 누락되면 에러를 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
@@ -26,12 +26,17 @@ public enum ErrorCode {
 
     // 게시글
     INVALID_POST(HttpStatus.BAD_REQUEST, "존재하지 않는 게시글 입니다."),
+    VIDEO_REQUIRED(HttpStatus.BAD_REQUEST, "영상을 첨부해주세요."),
+
     // 투표
     VOTE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 투표한 게시글 입니다."),
+
     // 댓글
     INVALID_COMMENT(HttpStatus.BAD_REQUEST, "부모 댓글이 없습니다."),
+
     // 해시태그
     HASHTAGNAME_NOT_MATCH(HttpStatus.BAD_REQUEST, "해시태그 이름이 일치하지 않습니다."),
+
     // 알람
     INVALID_ALARM(HttpStatus.BAD_REQUEST, "존재하지 않는 알람입니다." );
 

--- a/src/main/java/com/example/mdmggreal/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/mdmggreal/global/security/JwtAuthFilter.java
@@ -28,11 +28,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             String authentication = request.getHeader("Authorization");
 
             if (authentication != null || authentication.startsWith("Bearer ")) {
-                ;
-
-                if (jwtUtil.validateToken(authentication)) {
-                    String token = authentication.split(" ")[1].trim();
-                    Long memberId  = JwtUtil.getMemberId(token);
+                if (JwtUtil.validateToken(authentication)) {
+                    Long memberId  = JwtUtil.getMemberId(authentication);
 
                     UserDetails userDetails = customUserDetailsService.loadUserByUsername(memberId.toString());
 

--- a/src/main/java/com/example/mdmggreal/post/controller/PostController.java
+++ b/src/main/java/com/example/mdmggreal/post/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.example.mdmggreal.post.controller;
 
+import com.example.mdmggreal.global.exception.CustomException;
+import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.global.security.JwtUtil;
 import com.example.mdmggreal.post.dto.PostDTO;
 import com.example.mdmggreal.post.dto.request.PostAddRequest;
@@ -33,6 +35,9 @@ public class PostController {
                                                    @RequestPart("postAddRequest") PostAddRequest postAddRequest
     ) throws IOException {
         Long memberId = JwtUtil.getMemberId(token);
+        if (uploadVideos == null || uploadVideos.isEmpty()) {
+            throw new CustomException(ErrorCode.VIDEO_REQUIRED);
+        }
         String content = new String(contentFile.getBytes(), StandardCharsets.UTF_8);
 
         postService.addPost(uploadVideos, thumbnailImage, postAddRequest, content, memberId);

--- a/src/main/java/com/example/mdmggreal/post/dto/request/PostAddRequest.java
+++ b/src/main/java/com/example/mdmggreal/post/dto/request/PostAddRequest.java
@@ -7,7 +7,6 @@ import com.example.mdmggreal.post.entity.type.VideoType;
 import java.util.List;
 public record PostAddRequest(
         String title,
-//        String content,
         VideoType type,
         List<String> hashtag,
         List<InGameInfoRequest> inGameInfoRequests,


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 정책 상 게시글 작성 시 영상을 필수로 첨부해야하는데, Controller에서 검증하는 로직이 없음.
2. JwtAuthFilter에서, 사용자를 특정할 때 이번에 수정된 로직에 맞게 수정되어야했는데 수정이 안되어서, 헤더의 토큰을 통해 사용자를 특정을 못함.
---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. Controller에서 영상 첨부 여부 및 영상을 첨부했는데 내용이 비어있는 경우에 에러처리를 함.
2. 헤더의 토큰을 가져올 때 Bearer를 삭제하지 않고 그대로 member를 추출하는 로직으로 수정함.

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
1. inGameInfo도 2명 이상 작성하는게 필수이므로, 그 부분을 검증하는 로직도 추가되어야 하지 않을까 싶습니다!