### PR TITLE
Fix: 비회원도 댓글조회 가능하도록 수정

### DIFF
--- a/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
+++ b/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
@@ -31,9 +31,8 @@ public class CommentController {
     }
 
     @GetMapping
-    public ResponseEntity<CommentGetListResponse> commentGetList(@RequestHeader(value = "Authorization") String token, @PathVariable(value = "postid") Long postId) {
-        Long memberId = JwtUtil.getMemberId(token);
-        List<CommentDTO> commentList = commentService.getCommentList(postId, memberId);
+    public ResponseEntity<CommentGetListResponse> commentGetList(@PathVariable(value = "postid") Long postId) {
+        List<CommentDTO> commentList = commentService.getCommentList(postId);
         return ResponseEntity.ok(CommentGetListResponse.from(commentList, HttpStatus.OK));
     }
 

--- a/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
+++ b/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
@@ -58,7 +58,7 @@ public class CommentService {
     }
 
     @Transactional
-    public List<CommentDTO> getCommentList(Long postId, Long memberId) {
+    public List<CommentDTO> getCommentList(Long postId) {
         List<Comment> list = commentDAO.getList(postId);
         List<CommentDTO> commentResponseDTOList = new ArrayList<>();
         Map<Long, CommentDTO> commentDTOHashMap = new HashMap<>();


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 게시글은 비회원조회가 가능한데, 댓글은 비회원조회가 가능하도록 수정이 안되어있었음.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. 댓글도 비회원 조회가 가능하도록 수정함.


---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
1. token 여부에 따라 분기처리할 필요가 없는 로직이라서 따로 분기처리는 하지 않았습니다.
2. 추후 프론트와 협의해 댓글목록조회의 응답형식을 정리할 필요가 있을 것 같습니다. 