### PR TITLE
Fix: 알람목록조회 정렬조건 수정, 게시글/댓글 알람목록 개별조회 로직 삭제

### DIFF
--- a/src/main/java/com/example/mdmggreal/alarm/controller/AlarmController.java
+++ b/src/main/java/com/example/mdmggreal/alarm/controller/AlarmController.java
@@ -21,8 +21,11 @@ public class AlarmController {
 
     private final AlarmService alarmService;
 
+    /*
+    전체 알람 조회
+     */
     @GetMapping
-    public AlarmResponse alarmGet(@RequestHeader(value = "Authorization") String token) {
+    public AlarmResponse alarmListGet(@RequestHeader(value = "Authorization") String token) {
         Long memberId = JwtUtil.getMemberId(token);
         List<AlarmDTO> alarmList = alarmService.getAlarmList(memberId);
         return AlarmResponse.from(alarmList, OK);

--- a/src/main/java/com/example/mdmggreal/alarm/controller/CommentAlarmController.java
+++ b/src/main/java/com/example/mdmggreal/alarm/controller/CommentAlarmController.java
@@ -1,14 +1,10 @@
 package com.example.mdmggreal.alarm.controller;
 
-import com.example.mdmggreal.alarm.dto.AlarmDTO;
-import com.example.mdmggreal.alarm.dto.response.AlarmResponse;
 import com.example.mdmggreal.alarm.service.CommentAlarmService;
 import com.example.mdmggreal.global.response.BaseResponse;
 import com.example.mdmggreal.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 
@@ -18,13 +14,6 @@ import static org.springframework.http.HttpStatus.OK;
 public class CommentAlarmController {
 
     private final CommentAlarmService commentAlarmService;
-
-    @GetMapping
-    public AlarmResponse CommentAlarmGet(@RequestHeader(value = "Authorization") String token) {
-        Long memberId = JwtUtil.getMemberId(token);
-        List<AlarmDTO> commentAlarmList = commentAlarmService.getCommentAlarmList(memberId);
-        return AlarmResponse.from(commentAlarmList, OK);
-    }
 
     @PatchMapping("/{alarmId}")
     public BaseResponse CommentAlarmModify(@RequestHeader(value = "Authorization") String token, @PathVariable Long alarmId) {

--- a/src/main/java/com/example/mdmggreal/alarm/controller/PostAlarmController.java
+++ b/src/main/java/com/example/mdmggreal/alarm/controller/PostAlarmController.java
@@ -1,14 +1,10 @@
 package com.example.mdmggreal.alarm.controller;
 
-import com.example.mdmggreal.alarm.dto.AlarmDTO;
-import com.example.mdmggreal.alarm.dto.response.AlarmResponse;
 import com.example.mdmggreal.alarm.service.PostAlarmService;
 import com.example.mdmggreal.global.response.BaseResponse;
 import com.example.mdmggreal.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 
@@ -19,13 +15,6 @@ import static org.springframework.http.HttpStatus.OK;
 public class PostAlarmController {
 
     private final PostAlarmService postAlarmService;
-
-    @GetMapping
-    public AlarmResponse postAlarmGet(@RequestHeader(value = "Authorization") String token) {
-        Long memberId = JwtUtil.getMemberId(token);
-        List<AlarmDTO> postAlarmList = postAlarmService.getPostAlarmList(memberId);
-        return AlarmResponse.from(postAlarmList, OK);
-    }
 
     @PatchMapping("/{alarmId}")
     public BaseResponse CommentAlarmModify(@RequestHeader(value = "Authorization") String token, @PathVariable Long alarmId) {

--- a/src/main/java/com/example/mdmggreal/alarm/dto/AlarmDTO.java
+++ b/src/main/java/com/example/mdmggreal/alarm/dto/AlarmDTO.java
@@ -30,7 +30,7 @@ public class AlarmDTO {
         return AlarmDTO.builder()
                 .alarmId(postAlarm.getId())
                 .alarmContents(postAlarm.getAlarmContents())
-                .postId(postAlarm.getId())
+                .postId(postAlarm.getPost().getId())
                 .alarmType(POST)
                 .isRead(postAlarm.getIsRead())
                 .createdDateTime(postAlarm.getCreatedDateTime())
@@ -41,11 +41,10 @@ public class AlarmDTO {
         return AlarmDTO.builder()
                 .alarmId(commentAlarm.getId())
                 .alarmContents(commentAlarm.getAlarmContents())
-                .postId(commentAlarm.getId())
+                .commentId(commentAlarm.getComment().getId())
                 .alarmType(COMMENT)
                 .isRead(commentAlarm.getIsRead())
                 .createdDateTime(commentAlarm.getCreatedDateTime())
                 .build();
     }
-
 }

--- a/src/main/java/com/example/mdmggreal/alarm/dto/response/AlarmResponse.java
+++ b/src/main/java/com/example/mdmggreal/alarm/dto/response/AlarmResponse.java
@@ -12,13 +12,13 @@ import java.util.List;
 @Getter
 @SuperBuilder
 public class AlarmResponse extends BaseResponse {
-    private List<AlarmDTO> alarmDTOList;
+    private List<AlarmDTO> alarmList;
 
     public static AlarmResponse from(List<AlarmDTO> alarmDTOList, HttpStatus status) {
         return AlarmResponse.builder()
                 .resultCode(status.value())
                 .resultMsg(status.name())
-                .alarmDTOList(alarmDTOList)
+                .alarmList(alarmDTOList)
                 .build();
     }
 }

--- a/src/main/java/com/example/mdmggreal/alarm/entity/PostAlarm.java
+++ b/src/main/java/com/example/mdmggreal/alarm/entity/PostAlarm.java
@@ -40,9 +40,7 @@ public class PostAlarm extends BaseEntity {
                 .post(post)
                 .isRead(FALSE)
                 .build();
-
     }
-
 
     public void editIsRead() {
         this.isRead = true;

--- a/src/main/java/com/example/mdmggreal/alarm/service/AlarmService.java
+++ b/src/main/java/com/example/mdmggreal/alarm/service/AlarmService.java
@@ -24,7 +24,6 @@ public class AlarmService {
     private final MemberRepository memberRepository;
     private final CommentAlarmRepository commentAlarmRepository;
 
-
     public List<AlarmDTO> getAlarmList(Long memberId) {
         Member member = getMemberByMemberId(memberId);
         List<AlarmDTO> alarmDTOList = new ArrayList<>();
@@ -38,9 +37,10 @@ public class AlarmService {
                 .toList());
 
         return alarmDTOList.stream()
-                .sorted(Comparator.comparing(AlarmDTO::getCreatedDateTime).reversed())
+                .sorted(Comparator  // 정렬 1순위 : 안 읽은 순, 2순위 : 최근 순
+                        .comparing(AlarmDTO::getIsRead)
+                        .thenComparing(AlarmDTO::getCreatedDateTime, Comparator.reverseOrder()))
                 .collect(Collectors.toList());
-
     }
 
     private Member getMemberByMemberId(Long memberId) {

--- a/src/main/java/com/example/mdmggreal/alarm/service/CommentAlarmService.java
+++ b/src/main/java/com/example/mdmggreal/alarm/service/CommentAlarmService.java
@@ -1,6 +1,5 @@
 package com.example.mdmggreal.alarm.service;
 
-import com.example.mdmggreal.alarm.dto.AlarmDTO;
 import com.example.mdmggreal.alarm.entity.CommentAlarm;
 import com.example.mdmggreal.alarm.repository.CommentAlarmRepository;
 import com.example.mdmggreal.comment.dto.request.CommentAddRequest;
@@ -9,11 +8,8 @@ import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.member.entity.Member;
 import com.example.mdmggreal.member.repository.MemberRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
 
@@ -25,14 +21,6 @@ public class CommentAlarmService {
 
     public void addAlarm(Comment comment, CommentAddRequest request) {
         commentAlarmRepository.save(CommentAlarm.from(comment, request));
-    }
-
-    @Transactional
-    public List<AlarmDTO> getCommentAlarmList(Long memberId) {
-        Member member = getMemberByMemberId(memberId);
-        return commentAlarmRepository.findByMemberId(member.getId()).stream()
-                .map(AlarmDTO::from)
-                .toList();
     }
 
     public void modifyAlarm(Long memberId, Long alarmId) {

--- a/src/main/java/com/example/mdmggreal/alarm/service/PostAlarmService.java
+++ b/src/main/java/com/example/mdmggreal/alarm/service/PostAlarmService.java
@@ -1,6 +1,5 @@
 package com.example.mdmggreal.alarm.service;
 
-import com.example.mdmggreal.alarm.dto.AlarmDTO;
 import com.example.mdmggreal.alarm.entity.PostAlarm;
 import com.example.mdmggreal.alarm.repository.PostAlarmRepository;
 import com.example.mdmggreal.global.exception.CustomException;
@@ -11,8 +10,6 @@ import com.example.mdmggreal.post.entity.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
 
 @Service
@@ -20,13 +17,6 @@ import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
 public class PostAlarmService {
     private final PostAlarmRepository postAlarmRepository;
     private final MemberRepository memberRepository;
-
-    public List<AlarmDTO> getPostAlarmList(Long memberId) {
-        Member member = getMemberByMemberId(memberId);
-        return postAlarmRepository.findByMemberId(member.getId()).stream()
-                .map(AlarmDTO::from)
-                .toList();
-    }
 
     public void addAlarm(Post post, Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 전체알람목록 조회 시 최신순으로 정렬
2. 전체알람목록 조회, 게시글알람목록 조회, 댓글알람목록 조회 api가 각각 다른 Controller 파일에서 관리됨.
3. AlarmDTO의 from 메서드에서 commentId, postId에 alarmId가 잘못들어가있음.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. 정책 변경에 따라 안읽은 순, 최신 순 순서로 정렬 수정
2. 게시글알람목록조회, 댓글알람목록 조회 api 삭제, 전체알람목록 조회로 통일. alarmType 필드를 통해 프론트에서 게시글알람, 댓글알람으로 구분.
3. commentId와 postId 각각 올바른 값이 들어가도록 수정

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
- 메서드명, 필드명을 다른 메서드들, 필드들과 통일감있게 수정한 부분도 있으니 확인 부탁드립니다~