### PR TITLE
Fix: 댓글 작성 시 내용이 없으면 댓글 작성 못하도록 수정, validation 라이브러리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
+++ b/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.example.mdmggreal.comment.dto.response.CommentGetListResponse;
 import com.example.mdmggreal.comment.service.CommentService;
 import com.example.mdmggreal.global.response.BaseResponse;
 import com.example.mdmggreal.global.security.JwtUtil;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,12 +23,12 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<BaseResponse> commentAdd(@RequestHeader(value = "Authorization") String token,
-                                                   @PathVariable(value = "postid") Long postId, @RequestBody CommentAddRequest request
+                                                   @PathVariable(value = "postid") Long postId,
+                                                   @RequestBody @Valid CommentAddRequest request
     ) {
         Long memberId = JwtUtil.getMemberId(token);
         commentService.addComment(postId, request, memberId);
         return ResponseEntity.ok(BaseResponse.from(HttpStatus.CREATED));
-
     }
 
     @GetMapping

--- a/src/main/java/com/example/mdmggreal/comment/dto/request/CommentAddRequest.java
+++ b/src/main/java/com/example/mdmggreal/comment/dto/request/CommentAddRequest.java
@@ -1,5 +1,6 @@
 package com.example.mdmggreal.comment.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 public class CommentAddRequest {
+
     private Long parentId;
+
+    @NotNull(message = "댓글 내용을 작성해주세요")
     private String content;
 }

--- a/src/main/java/com/example/mdmggreal/comment/dto/request/CommentAddRequest.java
+++ b/src/main/java/com/example/mdmggreal/comment/dto/request/CommentAddRequest.java
@@ -1,6 +1,6 @@
 package com.example.mdmggreal.comment.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +14,6 @@ public class CommentAddRequest {
 
     private Long parentId;
 
-    @NotNull(message = "댓글 내용을 작성해주세요")
+    @NotBlank(message = "댓글 내용을 작성해주세요.")
     private String content;
 }


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 댓글 작성 요청 데이터에 validation이 걸려있지 않아서 요청데이터를 잘못 보냈는데도 댓글이 작성됨.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. validation 라이브러리를 추가하고, Request의 필수 필드인 content에 NotBlank 어노테이션을 추가해 검증함.


---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
1. 추후 GlobalExceptionHandler을 작성해서 validation 오류에 따른 메세지도 클라이언트에서 확인할 수 있도록 하면 좋을 것 같습니다.
현재는 validation을 통해 message 를 설정해도 응답데이터는 400 Bad Request 로만 반환됩니다. 
2. 잘못 작성되어 content가 null로 저장된 댓글들은 전부 삭제해뒀습니다!