### PR TITLE
Fix: 대댓글 작성 시 게시글에 존재하는 댓글에 대해 요청을 보내는 지 검증하는 로직 추가

### DIFF
--- a/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     // 댓글
     INVALID_COMMENT(HttpStatus.BAD_REQUEST, "부모 댓글이 없습니다."),
     COMMENT_NOT_EXISTS(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다"),
+    INVALID_PARENT_ID(HttpStatus.BAD_REQUEST, "postId에 맞는 parentId인지 확인해주세요."),
 
     // 해시태그
     HASHTAGNAME_NOT_MATCH(HttpStatus.BAD_REQUEST, "해시태그 이름이 일치하지 않습니다."),


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 대댓글 작성 시 parentId를 포함해서 요청하는데, 그 부모댓글이 파라미터로 보내는 게시글에 존재하는 댓글인지 검증하는 로직이 없어서 postman으로 api 테스트를 하니 잘못된 데이터가 저장됨. 

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. 혹시 모를 에러를 대비해서 검증하는 로직을 추가했습니다. 

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
