### PR TITLE
Fix: 댓글/게시글 알람 읽음 처리 안되던 것 수정

### DIFF
--- a/src/main/java/com/example/mdmggreal/alarm/controller/CommentAlarmController.java
+++ b/src/main/java/com/example/mdmggreal/alarm/controller/CommentAlarmController.java
@@ -16,7 +16,7 @@ public class CommentAlarmController {
     private final CommentAlarmService commentAlarmService;
 
     @PatchMapping("/{alarmId}")
-    public BaseResponse CommentAlarmModify(@RequestHeader(value = "Authorization") String token, @PathVariable Long alarmId) {
+    public BaseResponse commentAlarmModify(@RequestHeader(value = "Authorization") String token, @PathVariable Long alarmId) {
         Long memberId = JwtUtil.getMemberId(token);
         commentAlarmService.modifyAlarm(memberId, alarmId);
 

--- a/src/main/java/com/example/mdmggreal/alarm/entity/CommentAlarm.java
+++ b/src/main/java/com/example/mdmggreal/alarm/entity/CommentAlarm.java
@@ -1,6 +1,5 @@
 package com.example.mdmggreal.alarm.entity;
 
-import com.example.mdmggreal.comment.dto.request.CommentAddRequest;
 import com.example.mdmggreal.comment.entity.Comment;
 import com.example.mdmggreal.global.entity.BaseEntity;
 import com.example.mdmggreal.member.entity.Member;

--- a/src/main/java/com/example/mdmggreal/alarm/service/CommentAlarmService.java
+++ b/src/main/java/com/example/mdmggreal/alarm/service/CommentAlarmService.java
@@ -11,6 +11,7 @@ import com.example.mdmggreal.post.entity.Post;
 import com.example.mdmggreal.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
 
@@ -40,6 +41,7 @@ public class CommentAlarmService {
         commentAlarmRepository.save(CommentAlarm.from(addedComment, commentedNickname, alarmedMember));
     }
 
+    @Transactional
     public void modifyAlarm(Long memberId, Long alarmId) {
         Member member = getMemberByMemberId(memberId);
         CommentAlarm commentAlarm = commentAlarmRepository.findById(alarmId).orElseThrow(
@@ -50,7 +52,6 @@ public class CommentAlarmService {
         }
 
         commentAlarm.editIsRead();
-
     }
 
     private Member getMemberByMemberId(Long memberId) {

--- a/src/main/java/com/example/mdmggreal/alarm/service/PostAlarmService.java
+++ b/src/main/java/com/example/mdmggreal/alarm/service/PostAlarmService.java
@@ -30,6 +30,7 @@ public class PostAlarmService {
         postAlarmRepository.save(PostAlarm.ofPostedMember(postedMember, post));
     }
 
+    @Transactional
     public void modifyAlarm(Long memberId, Long alarmId) {
         Member member = getMemberByMemberId(memberId);
         PostAlarm postAlarm = postAlarmRepository.findById(alarmId).orElseThrow(


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 댓글, 게시글 알람을 읽어도, 디비에서 isRead 필드가 true로 변하지 않았음.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. @Transactional 어노테이션을 추가해 영속성 컨텍스트에서 관리되도록 하여 데이터베이스에 결과를 반영하였습니다.

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
