### PR TITLE
Fix: 동영상,링크 미첨부 exception 처리 및 썸네일 미첨부시 분기처리 및 video 네이밍 통일

### DIFF
--- a/src/main/generated/com/example/mdmggreal/alarm/entity/QCommentAlarm.java
+++ b/src/main/generated/com/example/mdmggreal/alarm/entity/QCommentAlarm.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QCommentAlarm is a Querydsl query type for CommentAlarm
+ * QCommentAlarm is a Querydsl query videoType for CommentAlarm
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QCommentAlarm extends EntityPathBase<CommentAlarm> {

--- a/src/main/generated/com/example/mdmggreal/alarm/entity/QPostAlarm.java
+++ b/src/main/generated/com/example/mdmggreal/alarm/entity/QPostAlarm.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QPostAlarm is a Querydsl query type for PostAlarm
+ * QPostAlarm is a Querydsl query videoType for PostAlarm
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QPostAlarm extends EntityPathBase<PostAlarm> {

--- a/src/main/generated/com/example/mdmggreal/comment/entity/QComment.java
+++ b/src/main/generated/com/example/mdmggreal/comment/entity/QComment.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QComment is a Querydsl query type for Comment
+ * QComment is a Querydsl query videoType for Comment
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QComment extends EntityPathBase<Comment> {

--- a/src/main/generated/com/example/mdmggreal/global/entity/QBaseEntity.java
+++ b/src/main/generated/com/example/mdmggreal/global/entity/QBaseEntity.java
@@ -10,7 +10,7 @@ import com.querydsl.core.types.Path;
 
 
 /**
- * QBaseEntity is a Querydsl query type for BaseEntity
+ * QBaseEntity is a Querydsl query videoType for BaseEntity
  */
 @Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
 public class QBaseEntity extends EntityPathBase<BaseEntity> {

--- a/src/main/generated/com/example/mdmggreal/hashtag/entity/QHashtag.java
+++ b/src/main/generated/com/example/mdmggreal/hashtag/entity/QHashtag.java
@@ -10,7 +10,7 @@ import com.querydsl.core.types.Path;
 
 
 /**
- * QHashtag is a Querydsl query type for Hashtag
+ * QHashtag is a Querydsl query videoType for Hashtag
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QHashtag extends EntityPathBase<Hashtag> {

--- a/src/main/generated/com/example/mdmggreal/ingameinfo/entity/QInGameInfo.java
+++ b/src/main/generated/com/example/mdmggreal/ingameinfo/entity/QInGameInfo.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QInGameInfo is a Querydsl query type for InGameInfo
+ * QInGameInfo is a Querydsl query videoType for InGameInfo
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QInGameInfo extends EntityPathBase<InGameInfo> {

--- a/src/main/generated/com/example/mdmggreal/member/entity/QMember.java
+++ b/src/main/generated/com/example/mdmggreal/member/entity/QMember.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QMember is a Querydsl query type for Member
+ * QMember is a Querydsl query videoType for Member
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QMember extends EntityPathBase<Member> {

--- a/src/main/generated/com/example/mdmggreal/member/type/QAgree.java
+++ b/src/main/generated/com/example/mdmggreal/member/type/QAgree.java
@@ -10,7 +10,7 @@ import com.querydsl.core.types.Path;
 
 
 /**
- * QAgree is a Querydsl query type for Agree
+ * QAgree is a Querydsl query videoType for Agree
  */
 @Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
 public class QAgree extends BeanPath<Agree> {

--- a/src/main/generated/com/example/mdmggreal/post/entity/QPost.java
+++ b/src/main/generated/com/example/mdmggreal/post/entity/QPost.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QPost is a Querydsl query type for Post
+ * QPost is a Querydsl query videoType for Post
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QPost extends EntityPathBase<Post> {

--- a/src/main/generated/com/example/mdmggreal/post/entity/QVideo.java
+++ b/src/main/generated/com/example/mdmggreal/post/entity/QVideo.java
@@ -10,7 +10,7 @@ import com.querydsl.core.types.Path;
 
 
 /**
- * QVideo is a Querydsl query type for Video
+ * QVideo is a Querydsl query videoType for Video
  */
 @Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
 public class QVideo extends BeanPath<Video> {

--- a/src/main/generated/com/example/mdmggreal/posthashtag/entity/QPostHashtag.java
+++ b/src/main/generated/com/example/mdmggreal/posthashtag/entity/QPostHashtag.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QPostHashtag is a Querydsl query type for PostHashtag
+ * QPostHashtag is a Querydsl query videoType for PostHashtag
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QPostHashtag extends EntityPathBase<PostHashtag> {

--- a/src/main/generated/com/example/mdmggreal/vote/entity/QVote.java
+++ b/src/main/generated/com/example/mdmggreal/vote/entity/QVote.java
@@ -11,7 +11,7 @@ import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
- * QVote is a Querydsl query type for Vote
+ * QVote is a Querydsl query videoType for Vote
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QVote extends EntityPathBase<Vote> {

--- a/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
@@ -26,7 +26,10 @@ public enum ErrorCode {
 
     // 게시글
     INVALID_POST(HttpStatus.BAD_REQUEST, "존재하지 않는 게시글 입니다."),
-    VIDEO_REQUIRED(HttpStatus.BAD_REQUEST, "영상을 첨부해주세요."),
+    VIDEO_REQUIRED(HttpStatus.BAD_REQUEST, "영상링크 또는 파일을 첨부해주세요."),
+    VIDEO_LINK_REQUIRED(HttpStatus.BAD_REQUEST, "영상링크를 첨부해주세요."),
+    VIDEO_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "영상파일을 첨부해주세요."),
+
 
     // 투표
     VOTE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 투표한 게시글 입니다."),
@@ -41,9 +44,8 @@ public enum ErrorCode {
     HASHTAGNAME_NOT_MATCH(HttpStatus.BAD_REQUEST, "해시태그 이름이 일치하지 않습니다."),
 
     // 알람
-    INVALID_ALARM(HttpStatus.BAD_REQUEST, "존재하지 않는 알람입니다." ),
-    NOT_MATCH_IN_GAME_INFO(HttpStatus.BAD_REQUEST, "게시글에 해당하는 인게임 정보가 아닙니다." );
-
+    INVALID_ALARM(HttpStatus.BAD_REQUEST, "존재하지 않는 알람입니다."),
+    NOT_MATCH_IN_GAME_INFO(HttpStatus.BAD_REQUEST, "게시글에 해당하는 인게임 정보가 아닙니다.");
     private final HttpStatus httpStatus;
     private final String message;
-}
+    }

--- a/src/main/java/com/example/mdmggreal/post/dto/request/PostAddRequest.java
+++ b/src/main/java/com/example/mdmggreal/post/dto/request/PostAddRequest.java
@@ -5,17 +5,14 @@ import com.example.mdmggreal.ingameinfo.dto.request.InGameInfoRequest;
 import com.example.mdmggreal.post.entity.type.VideoType;
 
 import java.util.List;
+
 public record PostAddRequest(
         String title,
-        VideoType type,
+        VideoType videoType,
         List<String> hashtag,
         List<InGameInfoRequest> inGameInfoRequests,
-        String videoUrl
+        String videoLink
 ) {
-
-
-
-
 
 
 }

--- a/src/main/java/com/example/mdmggreal/post/entity/Post.java
+++ b/src/main/java/com/example/mdmggreal/post/entity/Post.java
@@ -52,7 +52,7 @@ public class Post extends BaseEntity {
                 .content(content)
                 .thumbnailURL(thumbnailURL)
                 .status(PROGRESS)
-                .video(Video.of(videoUrl, request.type()))
+                .video(Video.of(videoUrl, request.videoType()))
                 .viewCount(0L)
                 .endDateTime(LocalDateTime.now().plusMonths(1).with(LocalTime.MIN))
                 .build();


### PR DESCRIPTION
### AS - IS
- 동영상파일 첨부를 안했을 경우 대한 exception 처리만 되어있어서, 동영상링크를 첨부하고 동영상파일을 첨부안했을 경우 에러발생
- uploadVideos, videlUrl 이렇게 명칭이 통일되지 않아 어떤역할을 하는 필드인지 한눈에 알아볼 수 없었음

---
### TO - BE
변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
- uploadVideos, videlUrl를 videoFile, videoLink로 변경
- 동영상 첨부에 대한 예외처리
   1. 비디오파일,비디오링크 두개다 첨부하지 안핬을 경우 예외처리
   2. 타입이 FILE이면서 비디오파일을 첨부안했을 경우 예외처리
   3. 타입이 LINK이면서 비디오링크를 첨부안했을 경우 예외처리

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
