### PR TITLE
Fix: 투표 시 인게임 정보 및 투표 총합 검증로직 추가

### DIFF
--- a/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
 
     // 투표
     VOTE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 투표한 게시글 입니다."),
+    VOTES_TOTAL_VALUE_MUST_BE_TEN(HttpStatus.BAD_REQUEST, "모든 투표값의 합은 10이어야합니다."),
+    ALL_IN_GAME_INFO_VOTE_REQUIRED(HttpStatus.BAD_REQUEST, "게시글의 모든 투표 항목에 투표해주세요."),
     NO_PERMISSION_TO_VIEW_RESULT(HttpStatus.UNAUTHORIZED, "투표 결과는 글 작성자와 투표 참여자만 조회할 수 있습니다."),
 
     // 댓글

--- a/src/main/java/com/example/mdmggreal/vote/service/VoteService.java
+++ b/src/main/java/com/example/mdmggreal/vote/service/VoteService.java
@@ -39,16 +39,16 @@ public class VoteService {
     private final InGameInfoRepository inGameInfoRepository;
 
     @Transactional
-    public void saveVotes(List<VoteSaveDTO> voteSaveDTOS, Long memberId, Long postId) {
+    public void saveVotes(List<VoteSaveDTO> voteSaveDTOs, Long memberId, Long postId) {
         Member member = getMemberById(memberId);
         List<InGameInfo> inGameInfoList = inGameInfoRepository.findByPostId(postId);
 
         validateVoteExistence(postId, member);
-        validateInGameInfoId(postId, inGameInfoList, voteSaveDTOS);
-        validateVotesTotalValue(voteSaveDTOS);
+        validateInGameInfoId(postId, inGameInfoList, voteSaveDTOs);
+        validateVotesTotalValue(voteSaveDTOs);
 
         updateMemberAfterVote(member);
-        List<Vote> votes = convertToVoteEntities(voteSaveDTOS, memberId);
+        List<Vote> votes = convertToVoteEntities(voteSaveDTOs, memberId);
 
         for (InGameInfo inGameInfo : inGameInfoList) {
             Double averageRatioByPostId = inGameInfoQueryRepository.getAverageRatioByPostId(inGameInfo.getId());
@@ -104,21 +104,21 @@ public class VoteService {
         }
     }
 
-    private void validateInGameInfoId(Long postId, List<InGameInfo> inGameInfoList, List<VoteSaveDTO> voteSaveDTOS) {
-        for (VoteSaveDTO voteSaveDTO : voteSaveDTOS) {
+    private void validateInGameInfoId(Long postId, List<InGameInfo> inGameInfoList, List<VoteSaveDTO> voteSaveDTOs) {
+        for (VoteSaveDTO voteSaveDTO : voteSaveDTOs) {
             boolean exists = inGameInfoRepository.existsByIdAndPostId(voteSaveDTO.getIngameInfoId(), postId);
             if (!exists) {
                 throw new CustomException(NOT_MATCH_IN_GAME_INFO);
             }
         }
 
-        if (inGameInfoList.size() != voteSaveDTOS.size()) {
+        if (inGameInfoList.size() != voteSaveDTOs.size()) {
             throw new CustomException(ALL_IN_GAME_INFO_VOTE_REQUIRED);
         }
     }
 
-    private void validateVotesTotalValue(List<VoteSaveDTO> voteSaveDTOS) {
-        long sum = voteSaveDTOS.stream()
+    private void validateVotesTotalValue(List<VoteSaveDTO> voteSaveDTOs) {
+        long sum = voteSaveDTOs.stream()
                 .mapToLong(VoteSaveDTO::getRatio)
                 .sum();
         if (sum != 10) throw new CustomException(VOTES_TOTAL_VALUE_MUST_BE_TEN);
@@ -130,9 +130,9 @@ public class VoteService {
         member.updateTier(tier);
     }
 
-    private List<Vote> convertToVoteEntities(List<VoteSaveDTO> voteSaveDTOS, Long memberId) {
+    private List<Vote> convertToVoteEntities(List<VoteSaveDTO> voteSaveDTOs, Long memberId) {
         List<Vote> voteList = new ArrayList<>();
-        for (VoteSaveDTO voteSaveDTO : voteSaveDTOS) {
+        for (VoteSaveDTO voteSaveDTO : voteSaveDTOs) {
             voteList.add(convertToEntity(voteSaveDTO, memberId));
         }
 

--- a/src/main/java/com/example/mdmggreal/vote/service/VoteService.java
+++ b/src/main/java/com/example/mdmggreal/vote/service/VoteService.java
@@ -118,10 +118,9 @@ public class VoteService {
     }
 
     private void validateVotesTotalValue(List<VoteSaveDTO> voteSaveDTOS) {
-        int sum = 0;
-        for (VoteSaveDTO voteSaveDTO : voteSaveDTOS) {
-            sum += voteSaveDTO.getRatio();
-        }
+        long sum = voteSaveDTOS.stream()
+                .mapToLong(VoteSaveDTO::getRatio)
+                .sum();
         if (sum != 10) throw new CustomException(VOTES_TOTAL_VALUE_MUST_BE_TEN);
     }
 


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 게시글의 모든 인게임 정보에 투표하지 않아도 투표가 가능했음.
2. 투표 시 모든 인게임 정보의 투표값의 합이 10이 되지 않아도 투표가 가능했음.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1,2 -> 서비스 클래스에서 예외처리했습니다. 

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
1. 추가로, 기존에 private 메서드와 public 메서드가 섞여있어서 private 메서드를 아래쪽으로 위치 이동시켰습니다.