### PR TITLE
Fix: entity에 컬럼명 오타 수정, JoinColumn 안되어있는 컬럼에 어노테이션 추가

### DIFF
--- a/src/main/java/com/example/mdmggreal/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/example/mdmggreal/hashtag/entity/Hashtag.java
@@ -19,7 +19,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 public class Hashtag {
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "hastag_id")
+    @Column(name = "hashtag_id")
     private Long id;
     private String name;
 

--- a/src/main/java/com/example/mdmggreal/posthashtag/entity/PostHashtag.java
+++ b/src/main/java/com/example/mdmggreal/posthashtag/entity/PostHashtag.java
@@ -20,9 +20,11 @@ public class PostHashtag {
     private Long id;
 
     @ManyToOne
+    @JoinColumn(name = "post_id")
     private Post post;
 
     @ManyToOne
+    @JoinColumn(name = "hashtag_id")
     private Hashtag hashtag;
 
     public static PostHashtag of(Post post, Hashtag hashtag) {


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. PostHash 테이블의 post, hashtag에 JoinColumn 어노테이션이 없어서 디비에 컬럼명이 의도대로 생성되지 않았음
2. Hashtag 엔티티의 id에 오타가 있어서 jpa가 매핑을 제대로 하지 못함

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. JoinColumn 추가 
2. 오타 수정
---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
