### PR TITLE
Fix: 해시태그 공백포함 12자로 제한

### DIFF
--- a/src/main/java/com/example/mdmggreal/post/controller/PostController.java
+++ b/src/main/java/com/example/mdmggreal/post/controller/PostController.java
@@ -10,6 +10,7 @@ import com.example.mdmggreal.post.dto.response.PostGetListResponse;
 import com.example.mdmggreal.post.dto.response.PostGetResponse;
 import com.example.mdmggreal.post.entity.type.VideoType;
 import com.example.mdmggreal.post.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,7 @@ public class PostController {
                                                    @RequestPart("uploadVideos") MultipartFile videoFile,
                                                    @RequestPart("content") MultipartFile contentFile,
                                                    @RequestPart("thumbnailImage") MultipartFile thumbnailImage,
-                                                   @RequestPart("postAddRequest") PostAddRequest postAddRequest
+                                                   @RequestPart("postAddRequest") @Valid PostAddRequest postAddRequest
     ) throws IOException {
         Long memberId = JwtUtil.getMemberId(token);
         checkVideoAttachment(videoFile, postAddRequest);

--- a/src/main/java/com/example/mdmggreal/post/dto/request/PostAddRequest.java
+++ b/src/main/java/com/example/mdmggreal/post/dto/request/PostAddRequest.java
@@ -3,13 +3,14 @@ package com.example.mdmggreal.post.dto.request;
 
 import com.example.mdmggreal.ingameinfo.dto.request.InGameInfoRequest;
 import com.example.mdmggreal.post.entity.type.VideoType;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record PostAddRequest(
         String title,
         VideoType videoType,
-        List<String> hashtag,
+        List<@Size(max = 12, message = "해시태그는 공백포함 12자까지 작성가능합니다.") String> hashtag,
         List<InGameInfoRequest> inGameInfoRequests,
         String videoLink
 ) {


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 해시태그의 길이를 무제한으로 작성할 수 있었음. 요구사항 수정으로 12자로 제한

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. Request 객체에 Validation을 사용해 제한했습니다

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
