### PR TITLE
Feat: 회원의 승리판결수 배치기능 및 회원 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mdmggreal/ingameinfo/dto/response/InGameInfoDTO.java
+++ b/src/main/java/com/example/mdmggreal/ingameinfo/dto/response/InGameInfoDTO.java
@@ -1,11 +1,16 @@
 package com.example.mdmggreal.ingameinfo.dto.response;
 
 import com.example.mdmggreal.ingameinfo.entity.InGameInfo;
+import com.example.mdmggreal.ingameinfo.type.InGameTier;
+import com.example.mdmggreal.ingameinfo.type.Position;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Getter
 @SuperBuilder
+@NoArgsConstructor
 public class InGameInfoDTO {
 
     private Long inGameInfoId;
@@ -13,6 +18,17 @@ public class InGameInfoDTO {
     private String position;
     private String championName;
     private Double averageRatio;
+
+    @QueryProjection
+    public InGameInfoDTO(Long inGameInfoId, InGameTier tier, Position position, String championName, Double averageRatio) {
+        this.inGameInfoId = inGameInfoId;
+        this.tier = tier.getName();
+        this.position = position.getName();
+        this.championName = championName;
+        this.averageRatio = averageRatio;
+    }
+
+
 
     public static InGameInfoDTO of(InGameInfo inGameInfo, Double averageRatio) {
         return InGameInfoDTO.builder()

--- a/src/main/java/com/example/mdmggreal/ingameinfo/repository/InGameInfoQueryRepository.java
+++ b/src/main/java/com/example/mdmggreal/ingameinfo/repository/InGameInfoQueryRepository.java
@@ -1,7 +1,14 @@
 package com.example.mdmggreal.ingameinfo.repository;
 
+import com.example.mdmggreal.ingameinfo.dto.response.InGameInfoDTO;
+import com.example.mdmggreal.ingameinfo.dto.response.QInGameInfoDTO;
 import com.example.mdmggreal.ingameinfo.entity.InGameInfo;
-import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.example.mdmggreal.ingameinfo.entity.QInGameInfo;
+import com.example.mdmggreal.vote.entity.QVote;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.JPAExpressions;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
@@ -12,18 +19,36 @@ import static com.example.mdmggreal.vote.entity.QVote.vote;
 @Repository
 @Slf4j
 public class InGameInfoQueryRepository extends QuerydslRepositorySupport {
-    private final JPAQueryFactory jpaQueryFactory;
 
-    public InGameInfoQueryRepository(JPAQueryFactory jpaQueryFactory) {
+
+    public InGameInfoQueryRepository() {
         super(InGameInfo.class);
-        this.jpaQueryFactory = jpaQueryFactory;
     }
 
-    public InGameInfo getInGameInfoVoteMaxRatioByPostId(Long postId) {
+    public InGameInfoDTO getInGameInfoVoteMaxRatioByPostId(Long postId) {
+        QInGameInfo inGameInfo = QInGameInfo.inGameInfo;
+        QVote vote = QVote.vote;
+
+        NumberPath<Double> averageRatio = Expressions.numberPath(Double.class, "averageRatio");
+
+        QInGameInfoDTO qInGameInfoDTO = new QInGameInfoDTO(
+                inGameInfo.id,
+                inGameInfo.inGameTier,
+                inGameInfo.position,
+                inGameInfo.championName,
+                ExpressionUtils.as(
+                        JPAExpressions
+                                .select((vote.ratio.avg()).max())
+                                .from(vote)
+                                .where(vote.inGameInfo.id.eq(inGameInfo.id))
+                                .groupBy(vote.inGameInfo.id),
+                        "averageRatio"));
+
 
         return from(inGameInfo)
+                .select(qInGameInfoDTO)
+                .leftJoin(vote).on(inGameInfo.id.eq(vote.inGameInfo.id))
                 .where(inGameInfo.post.id.eq(postId))
-                .orderBy(vote.ratio.desc())
                 .fetchOne();
     }
 

--- a/src/main/java/com/example/mdmggreal/ingameinfo/service/InGameInfoService.java
+++ b/src/main/java/com/example/mdmggreal/ingameinfo/service/InGameInfoService.java
@@ -1,11 +1,15 @@
 package com.example.mdmggreal.ingameinfo.service;
 
-import com.example.mdmggreal.ingameinfo.entity.InGameInfo;
+import com.example.mdmggreal.ingameinfo.dto.response.InGameInfoDTO;
 import com.example.mdmggreal.ingameinfo.repository.InGameInfoQueryRepository;
+import com.example.mdmggreal.member.entity.Member;
 import com.example.mdmggreal.member.repository.MemberQueryRepository;
+import com.example.mdmggreal.member.type.MemberTier;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -17,18 +21,16 @@ public class InGameInfoService {
 
     @Transactional
     public void processInGameInfoByPostId(Long postId) {
-        InGameInfo inGameInfo = inGameInfoQueryRepository.getInGameInfoVoteMaxRatioByPostId(postId);
-        updateMembers(inGameInfo);
+        InGameInfoDTO inGameInfoVoteMaxRatioByPostId = inGameInfoQueryRepository.getInGameInfoVoteMaxRatioByPostId(postId);
+        updateMembers(inGameInfoVoteMaxRatioByPostId);
     }
 
-    private void updateMembers(InGameInfo inGameInfo) {
-//        List<Member> correctMembers = memberQueryRepository.getCorrectMember(inGameInfo.getId(), inGameInfo.getAverageRatio());
-//        correctMembers.forEach(Member::editPredictedResult);
-//
-//        List<Member> joinedMembers = memberQueryRepository.getJoinedMember(inGameInfo.getId());
-//        joinedMembers.forEach(member -> {
-//            Tier tier = Tier.getTier(member.getJoinedResult(), member.getPredictedResult());
-//            member.updateTier(tier);
-//        });
+    private void updateMembers(InGameInfoDTO inGameInfo) {
+        List<Member> correctMembers = memberQueryRepository.getCorrectMember(inGameInfo.getInGameInfoId(), inGameInfo.getAverageRatio());
+        correctMembers.forEach(Member::editPredictedResult);
+        correctMembers.forEach(member -> {
+            MemberTier tier = MemberTier.getTier(member.getJoinedResult(), member.getPredictedResult());
+            member.updateTier(tier);
+        });
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/controller/MemberController.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.mdmggreal.member.controller;
 
 import com.example.mdmggreal.global.security.JwtUtil;
+import com.example.mdmggreal.member.dto.MemberDTO;
 import com.example.mdmggreal.member.dto.request.SignUpRequest;
 import com.example.mdmggreal.member.dto.request.TokenRefreshRequest;
 import com.example.mdmggreal.member.dto.response.NicknameCheckResponse;
@@ -46,5 +47,11 @@ public class MemberController {
     public ResponseEntity<TokenRefreshResponse> tokenRefresh(@RequestBody TokenRefreshRequest request) {
         AuthTokens tokens = jwtUtil.refreshTokens(request.getRefreshToken());
         return ResponseEntity.ok(TokenRefreshResponse.of(HttpStatus.OK, tokens));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<MemberResponse> getMember(@PathVariable(value = "userId") Long userId) {
+        MemberDTO memberDTO = memberService.memberGet(userId);
+        return ResponseEntity.ok(MemberResponse.of(HttpStatus.OK, memberDTO));
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/controller/MemberController.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.example.mdmggreal.member.controller;
 
 import com.example.mdmggreal.global.security.JwtUtil;
-import com.example.mdmggreal.member.dto.MemberDTO;
 import com.example.mdmggreal.member.dto.request.SignUpRequest;
 import com.example.mdmggreal.member.dto.request.TokenRefreshRequest;
 import com.example.mdmggreal.member.dto.response.NicknameCheckResponse;
@@ -49,10 +48,4 @@ public class MemberController {
         return ResponseEntity.ok(TokenRefreshResponse.of(HttpStatus.OK, tokens));
     }
 
-    @GetMapping
-    public ResponseEntity<MemberResponse> getMember(@RequestHeader(value = "Authorization") String token) {
-        Long memberId = JwtUtil.getMemberId(token);
-        MemberDTO memberDTO = memberService.memberGet(memberId);
-        return ResponseEntity.ok(MemberResponse.of(HttpStatus.OK, memberDTO));
-    }
 }

--- a/src/main/java/com/example/mdmggreal/member/controller/MemberController.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MemberController.java
@@ -49,9 +49,10 @@ public class MemberController {
         return ResponseEntity.ok(TokenRefreshResponse.of(HttpStatus.OK, tokens));
     }
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<MemberResponse> getMember(@PathVariable(value = "userId") Long userId) {
-        MemberDTO memberDTO = memberService.memberGet(userId);
+    @GetMapping
+    public ResponseEntity<MemberResponse> getMember(@RequestHeader(value = "Authorization") String token) {
+        Long memberId = JwtUtil.getMemberId(token);
+        MemberDTO memberDTO = memberService.memberGet(memberId);
         return ResponseEntity.ok(MemberResponse.of(HttpStatus.OK, memberDTO));
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/controller/MemberResponse.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MemberResponse.java
@@ -1,0 +1,23 @@
+package com.example.mdmggreal.member.controller;
+
+import com.example.mdmggreal.global.response.BaseResponse;
+import com.example.mdmggreal.member.dto.MemberDTO;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@SuperBuilder
+public class MemberResponse extends BaseResponse {
+    private MemberDTO memberDTO;
+
+    public static MemberResponse of(HttpStatus status, MemberDTO memberDTO) {
+        return MemberResponse.builder()
+                .resultCode(status.value())
+                .resultMsg(status.name())
+                .memberDTO(memberDTO)
+                .build();
+
+    }
+}
+

--- a/src/main/java/com/example/mdmggreal/member/controller/MemberResponse.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MemberResponse.java
@@ -1,7 +1,7 @@
 package com.example.mdmggreal.member.controller;
 
 import com.example.mdmggreal.global.response.BaseResponse;
-import com.example.mdmggreal.member.dto.MemberDTO;
+import com.example.mdmggreal.member.dto.response.MemberProfileDTO;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.http.HttpStatus;
@@ -9,13 +9,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @SuperBuilder
 public class MemberResponse extends BaseResponse {
-    private MemberDTO memberDTO;
+    private MemberProfileDTO memberProfileDTO;
 
-    public static MemberResponse of(HttpStatus status, MemberDTO memberDTO) {
+    public static MemberResponse of(HttpStatus status, MemberProfileDTO memberProfileDTO) {
         return MemberResponse.builder()
                 .resultCode(status.value())
                 .resultMsg(status.name())
-                .memberDTO(memberDTO)
+                .memberProfileDTO(memberProfileDTO)
                 .build();
 
     }

--- a/src/main/java/com/example/mdmggreal/member/controller/MyPageController.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MyPageController.java
@@ -30,7 +30,7 @@ public class MyPageController {
     @GetMapping
     public ResponseEntity<MemberResponse> getMember(@RequestHeader(value = "Authorization") String token) {
         Long memberId = JwtUtil.getMemberId(token);
-        MemberProfileDTO memberProfileDTO = memberService.memberGet(memberId);
+        MemberProfileDTO memberProfileDTO = myPageService.memberGet(memberId);
         return ResponseEntity.ok(MemberResponse.of(HttpStatus.OK, memberProfileDTO));
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/controller/MyPageController.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MyPageController.java
@@ -3,7 +3,6 @@ package com.example.mdmggreal.member.controller;
 import com.example.mdmggreal.global.security.JwtUtil;
 import com.example.mdmggreal.member.dto.response.MemberProfileDTO;
 import com.example.mdmggreal.member.dto.response.PostsByMemberGetResponse;
-import com.example.mdmggreal.member.service.MemberService;
 import com.example.mdmggreal.member.service.MyPageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MyPageController {
     private final MyPageService myPageService;
-    private final MemberService memberService;
 
     // TODO member 패키지에 위치시킬지, post 패키지에 위치시킬지 확정 후 주석 삭제
     @GetMapping("/post")

--- a/src/main/java/com/example/mdmggreal/member/controller/MyPageController.java
+++ b/src/main/java/com/example/mdmggreal/member/controller/MyPageController.java
@@ -1,9 +1,12 @@
 package com.example.mdmggreal.member.controller;
 
 import com.example.mdmggreal.global.security.JwtUtil;
+import com.example.mdmggreal.member.dto.response.MemberProfileDTO;
 import com.example.mdmggreal.member.dto.response.PostsByMemberGetResponse;
+import com.example.mdmggreal.member.service.MemberService;
 import com.example.mdmggreal.member.service.MyPageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -11,15 +14,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/mypage")
 @RequiredArgsConstructor
 public class MyPageController {
     private final MyPageService myPageService;
+    private final MemberService memberService;
 
     // TODO member 패키지에 위치시킬지, post 패키지에 위치시킬지 확정 후 주석 삭제
     @GetMapping("/post")
     public ResponseEntity<PostsByMemberGetResponse> postsByMemberGet(@RequestHeader(value = "Authorization") String token) {
         Long memberId = JwtUtil.getMemberId(token);
         return ResponseEntity.ok(myPageService.getPostsByMember(memberId));
+    }
+
+    @GetMapping
+    public ResponseEntity<MemberResponse> getMember(@RequestHeader(value = "Authorization") String token) {
+        Long memberId = JwtUtil.getMemberId(token);
+        MemberProfileDTO memberProfileDTO = memberService.memberGet(memberId);
+        return ResponseEntity.ok(MemberResponse.of(HttpStatus.OK, memberProfileDTO));
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/dto/MemberDTO.java
+++ b/src/main/java/com/example/mdmggreal/member/dto/MemberDTO.java
@@ -32,6 +32,9 @@ public class MemberDTO  {
     private boolean agreeTerms;
     private boolean agreePrivacy;
     private boolean agreePromotion;
+    private Integer predictedResult;
+    private Integer joinedResult;
+    private Integer point;
 
     public static MemberDTO from(Member member) {
         return MemberDTO.builder()
@@ -39,6 +42,9 @@ public class MemberDTO  {
                 .email(member.getEmail())
                 .mobile(member.getMobile())
                 .tier(member.getMemberTier().getName())
+                .predictedResult(member.getPredictedResult())
+                .joinedResult(member.getJoinedResult())
+                .point(member.getPoint())
                 .build();
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/dto/response/MemberProfileDTO.java
+++ b/src/main/java/com/example/mdmggreal/member/dto/response/MemberProfileDTO.java
@@ -1,0 +1,38 @@
+package com.example.mdmggreal.member.dto.response;
+
+import com.example.mdmggreal.member.entity.Member;
+import com.example.mdmggreal.member.type.MemberTier;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberProfileDTO {
+    private Long id;
+    private String nickName;
+    private Integer point;
+    private Integer joinedResult;
+    private Integer nextJoinedResult;
+    private Integer predicateResult;
+    private Integer nextPredicateResult;
+    private MemberTier tier;
+
+    public static MemberProfileDTO from(Member member) {
+        MemberTier nextTier = MemberTier.getNextTier(member.getMemberTier());
+        return MemberProfileDTO.builder()
+                .id(member.getId())
+                .point(member.getPoint())
+                .joinedResult(member.getJoinedResult())
+                .nextJoinedResult(nextTier.getJoinedResult())
+                .predicateResult((member.getPredictedResult()))
+                .nextPredicateResult(nextTier.getPredictedResult())
+                .tier(member.getMemberTier())
+                .nickName(member.getNickname())
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/mdmggreal/member/dto/response/MemberProfileDTO.java
+++ b/src/main/java/com/example/mdmggreal/member/dto/response/MemberProfileDTO.java
@@ -23,6 +23,7 @@ public class MemberProfileDTO {
 
     public static MemberProfileDTO from(Member member) {
         MemberTier nextTier = MemberTier.getNextTier(member.getMemberTier());
+        assert nextTier != null;
         return MemberProfileDTO.builder()
                 .id(member.getId())
                 .point(member.getPoint())

--- a/src/main/java/com/example/mdmggreal/member/entity/Member.java
+++ b/src/main/java/com/example/mdmggreal/member/entity/Member.java
@@ -145,4 +145,9 @@ public class Member extends BaseEntity {
     public void rewardPointByPostCreation(Integer point) {
         this.point += point;
     }
+
+    public void editPredictedResult() {
+        this.predictedResult += 1;
+
+    }
 }

--- a/src/main/java/com/example/mdmggreal/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/example/mdmggreal/member/repository/MemberQueryRepository.java
@@ -14,23 +14,21 @@ import static com.example.mdmggreal.vote.entity.QVote.vote;
 @Repository
 @Slf4j
 public class MemberQueryRepository extends QuerydslRepositorySupport {
-    private final JPAQueryFactory jpaQueryFactory;
 
     public MemberQueryRepository(JPAQueryFactory jpaQueryFactory) {
         super(Member.class);
-        this.jpaQueryFactory = jpaQueryFactory;
     }
 
     public List<Member> getCorrectMember(Long inGameInfoId, Double avgRatio) {
-        return jpaQueryFactory.selectFrom(member)
+        return from(member)
                 .leftJoin(vote).on(member.id.eq(vote.memberId))
                 .where(vote.inGameInfo.id.eq(inGameInfoId)
-                        .and(vote.ratio.goe(avgRatio)))
+                        .and(vote.ratio.lt(avgRatio)))
                 .fetch();
     }
 
     public List<Member> getJoinedMember(Long inGameInfoId) {
-        return jpaQueryFactory.selectFrom(member)
+        return from(member)
                 .leftJoin(vote).on(member.id.eq(vote.memberId))
                 .where(vote.inGameInfo.id.eq(inGameInfoId))
                 .fetch();

--- a/src/main/java/com/example/mdmggreal/member/service/MemberService.java
+++ b/src/main/java/com/example/mdmggreal/member/service/MemberService.java
@@ -4,8 +4,8 @@ import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.global.security.CustomUserInfoDto;
 import com.example.mdmggreal.global.security.JwtUtil;
-import com.example.mdmggreal.member.dto.MemberDTO;
 import com.example.mdmggreal.member.dto.request.SignUpRequest;
+import com.example.mdmggreal.member.dto.response.MemberProfileDTO;
 import com.example.mdmggreal.member.dto.response.SignUpResponse;
 import com.example.mdmggreal.member.entity.Member;
 import com.example.mdmggreal.member.repository.MemberRepository;
@@ -39,10 +39,10 @@ public class MemberService {
         }
     }
 
-    public MemberDTO memberGet(Long memberId) {
+    public MemberProfileDTO memberGet(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new CustomException(ErrorCode.INVALID_USER_ID)
         );
-        return MemberDTO.from(member);
+        return MemberProfileDTO.from(member);
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/service/MemberService.java
+++ b/src/main/java/com/example/mdmggreal/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.global.security.CustomUserInfoDto;
 import com.example.mdmggreal.global.security.JwtUtil;
+import com.example.mdmggreal.member.dto.MemberDTO;
 import com.example.mdmggreal.member.dto.request.SignUpRequest;
 import com.example.mdmggreal.member.dto.response.SignUpResponse;
 import com.example.mdmggreal.member.entity.Member;
@@ -38,4 +39,10 @@ public class MemberService {
         }
     }
 
+    public MemberDTO memberGet(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.INVALID_USER_ID)
+        );
+        return MemberDTO.from(member);
+    }
 }

--- a/src/main/java/com/example/mdmggreal/member/service/MemberService.java
+++ b/src/main/java/com/example/mdmggreal/member/service/MemberService.java
@@ -31,11 +31,7 @@ public class MemberService {
     }
 
     public Boolean checkNickname(String nickname) {
-        if (memberRepository.existsByNickname(nickname)) {
-            return true;
-        } else {
-            return false;
-        }
+        return memberRepository.existsByNickname(nickname);
     }
 
 }

--- a/src/main/java/com/example/mdmggreal/member/service/MemberService.java
+++ b/src/main/java/com/example/mdmggreal/member/service/MemberService.java
@@ -5,7 +5,6 @@ import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.global.security.CustomUserInfoDto;
 import com.example.mdmggreal.global.security.JwtUtil;
 import com.example.mdmggreal.member.dto.request.SignUpRequest;
-import com.example.mdmggreal.member.dto.response.MemberProfileDTO;
 import com.example.mdmggreal.member.dto.response.SignUpResponse;
 import com.example.mdmggreal.member.entity.Member;
 import com.example.mdmggreal.member.repository.MemberRepository;
@@ -39,10 +38,4 @@ public class MemberService {
         }
     }
 
-    public MemberProfileDTO memberGet(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(ErrorCode.INVALID_USER_ID)
-        );
-        return MemberProfileDTO.from(member);
-    }
 }

--- a/src/main/java/com/example/mdmggreal/member/service/MyPageService.java
+++ b/src/main/java/com/example/mdmggreal/member/service/MyPageService.java
@@ -1,6 +1,8 @@
 package com.example.mdmggreal.member.service;
 
 import com.example.mdmggreal.global.exception.CustomException;
+import com.example.mdmggreal.global.exception.ErrorCode;
+import com.example.mdmggreal.member.dto.response.MemberProfileDTO;
 import com.example.mdmggreal.member.dto.response.PostsByMemberGetResponse;
 import com.example.mdmggreal.member.entity.Member;
 import com.example.mdmggreal.member.repository.MemberRepository;
@@ -37,5 +39,12 @@ public class MyPageService {
         return memberRepository.findById(memberId).orElseThrow(
                 () -> new CustomException(INVALID_USER_ID)
         );
+    }
+
+    public MemberProfileDTO memberGet(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.INVALID_USER_ID)
+        );
+        return MemberProfileDTO.from(member);
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/type/MemberTier.java
+++ b/src/main/java/com/example/mdmggreal/member/type/MemberTier.java
@@ -23,22 +23,16 @@ public enum MemberTier {
     private final Integer joinedResultPoint;
     private final Integer postCreationPoint;
 
-    public static MemberTier fromName(String name) {
-        for (MemberTier memberTier : MemberTier.values()) {
-            if (memberTier.getName().equalsIgnoreCase(name)) {
-                return memberTier;
+    public static MemberTier getNextTier(MemberTier currentTier) {
+        MemberTier[] tiers = MemberTier.values();
+        if (!currentTier.equals(MemberTier.CHALLENGER)) {
+            for (int i = 0; i < tiers.length ; i++) {
+                if (tiers[i].joinedResultPoint.equals(currentTier.joinedResultPoint)) {
+                    return tiers[i - 1];
+                }
             }
         }
-        throw new IllegalArgumentException("No enum constant with name " + name);
-    }
-
-    public static String fromTier(MemberTier memberTier) {
-        for (MemberTier t : memberTier.values()) {
-            if (memberTier.equals(t)) {
-                return t.name;
-            }
-        }
-        throw new IllegalArgumentException("해당하는 티어가 없습니다. : " + memberTier);
+        return null;
     }
 
     public static MemberTier getTier(Integer joinedResult, Integer predictedResult) {


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
- 승리한 판결 수를 업데이트하는 로직이 존재하지 않았습니다.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
- 판결 종료시 회원의 승리한 판결 수 배치통한 업데이트 로직 구현
- 회원정보 조회 기능 구현

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
