### PR TITLE
Fix: 회원정보 api 에서 Tier 한글로 반환되게 수정

### DIFF
--- a/src/main/java/com/example/mdmggreal/member/dto/response/MemberProfileDTO.java
+++ b/src/main/java/com/example/mdmggreal/member/dto/response/MemberProfileDTO.java
@@ -19,7 +19,7 @@ public class MemberProfileDTO {
     private Integer nextJoinedResult;
     private Integer predicateResult;
     private Integer nextPredicateResult;
-    private MemberTier tier;
+    private String tier;
 
     public static MemberProfileDTO from(Member member) {
         MemberTier nextTier = MemberTier.getNextTier(member.getMemberTier());
@@ -31,7 +31,7 @@ public class MemberProfileDTO {
                 .nextJoinedResult(nextTier.getJoinedResult())
                 .predicateResult((member.getPredictedResult()))
                 .nextPredicateResult(nextTier.getPredictedResult())
-                .tier(member.getMemberTier())
+                .tier(member.getMemberTier().getName())
                 .nickName(member.getNickname())
                 .build();
 


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
- 현재 내회원정보 보기 api response에 tier가 "BRONZE" 영어로 반환되고 있었음

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
- "브론즈"로 반환되게 수정

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
