### PR TITLE
Fix: 판결 종료된 게시글에 투표 못하도록 수정

### DIFF
--- a/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 
     // 투표
     VOTE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 투표한 게시글 입니다."),
+    CANNOT_VOTE_TO_FINISHED_POST(HttpStatus.BAD_REQUEST, "종료된 게시글에는 투표할 수 없습니다."),
     VOTES_TOTAL_VALUE_MUST_BE_TEN(HttpStatus.BAD_REQUEST, "모든 투표값의 합은 10이어야합니다."),
     ALL_IN_GAME_INFO_VOTE_REQUIRED(HttpStatus.BAD_REQUEST, "게시글의 모든 투표 항목에 투표해주세요."),
     NO_PERMISSION_TO_VIEW_RESULT(HttpStatus.UNAUTHORIZED, "투표 결과는 글 작성자와 투표 참여자만 조회할 수 있습니다."),

--- a/src/main/java/com/example/mdmggreal/vote/controller/VoteController.java
+++ b/src/main/java/com/example/mdmggreal/vote/controller/VoteController.java
@@ -2,7 +2,6 @@ package com.example.mdmggreal.vote.controller;
 
 import com.example.mdmggreal.global.response.BaseResponse;
 import com.example.mdmggreal.global.security.JwtUtil;
-import com.example.mdmggreal.vote.dto.VoteResultResponse;
 import com.example.mdmggreal.vote.dto.request.VoteAddRequest;
 import com.example.mdmggreal.vote.service.VoteService;
 import lombok.AllArgsConstructor;


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
- 기존에 투표하기 api 에는 판결 종료된 게시글인지 확인하는 로직이 없었음.
프론트에서는 판결 종료된 게시글에 대해 투표가 막혀있었지만
백엔드에서는 막혀있지 않아, api 테스트 시 잘못된 투표를 할 가능성이 열려있었음.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
- 게시글의 상태를 조회해, 판결 종료된 게시글인지 확인하는 로직 추가

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
