### PR TITLE
Refactor: 회원 id로 Member 엔티티 조회 하는 서비스 생성하여 중복코드 제거

### DIFF
--- a/src/main/java/com/example/mdmggreal/alarm/service/AlarmService.java
+++ b/src/main/java/com/example/mdmggreal/alarm/service/AlarmService.java
@@ -9,7 +9,7 @@ import com.example.mdmggreal.comment.repository.CommentRepository;
 import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.member.entity.Member;
-import com.example.mdmggreal.member.repository.MemberRepository;
+import com.example.mdmggreal.member.service.MemberGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,19 +18,17 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
-
 @Service
 @RequiredArgsConstructor
 public class AlarmService {
 
     private final PostAlarmRepository postAlarmRepository;
-    private final MemberRepository memberRepository;
     private final CommentAlarmRepository commentAlarmRepository;
     private final CommentRepository commentRepository;
+    private final MemberGetService memberGetService;
 
     public List<AlarmDTO> getAlarmList(Long memberId) {
-        Member member = getMemberByMemberId(memberId);
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         List<AlarmDTO> alarmListResult = new ArrayList<>();
 
         // 게시글 알람 목록 조회 후 List에 추가
@@ -53,11 +51,5 @@ public class AlarmService {
                         .comparing(AlarmDTO::getIsRead)
                         .thenComparing(AlarmDTO::getCreatedDateTime, Comparator.reverseOrder()))
                 .collect(Collectors.toList());
-    }
-
-    private Member getMemberByMemberId(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(INVALID_USER_ID)
-        );
     }
 }

--- a/src/main/java/com/example/mdmggreal/alarm/service/PostAlarmService.java
+++ b/src/main/java/com/example/mdmggreal/alarm/service/PostAlarmService.java
@@ -5,23 +5,21 @@ import com.example.mdmggreal.alarm.repository.PostAlarmRepository;
 import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.member.entity.Member;
-import com.example.mdmggreal.member.repository.MemberRepository;
+import com.example.mdmggreal.member.service.MemberGetService;
 import com.example.mdmggreal.post.entity.Post;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
-
 @Service
 @RequiredArgsConstructor
 public class PostAlarmService {
     private final PostAlarmRepository postAlarmRepository;
-    private final MemberRepository memberRepository;
+    private final MemberGetService memberGetService;
 
     @Transactional
     public void addAlarm(Post post, Long memberId) {
-        Member votedMember = getMemberByMemberId(memberId);
+        Member votedMember = memberGetService.getMemberByIdOrThrow(memberId);
         Member postedMember = post.getMember();
 
         postAlarmRepository.save(PostAlarm.ofVotedMember(votedMember, post));
@@ -30,7 +28,7 @@ public class PostAlarmService {
 
     @Transactional
     public void modifyAlarm(Long memberId, Long alarmId) {
-        Member member = getMemberByMemberId(memberId);
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         PostAlarm postAlarm = postAlarmRepository.findById(alarmId).orElseThrow(
                 () -> new CustomException(ErrorCode.INVALID_ALARM)
         );
@@ -44,9 +42,4 @@ public class PostAlarmService {
         }
     }
 
-    private Member getMemberByMemberId(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(INVALID_USER_ID)
-        );
-    }
 }

--- a/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
+++ b/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
@@ -9,7 +9,7 @@ import com.example.mdmggreal.comment.repository.CommentRepository;
 import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.member.entity.Member;
-import com.example.mdmggreal.member.repository.MemberRepository;
+import com.example.mdmggreal.member.service.MemberGetService;
 import com.example.mdmggreal.post.entity.Post;
 import com.example.mdmggreal.post.repository.PostRepository;
 import jakarta.transaction.Transactional;
@@ -32,15 +32,14 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
-    private final MemberRepository memberRepository;
     private final CommentDAO commentDAO;
     private final CommentAlarmService commentAlarmService;
+    private final MemberGetService memberGetService;
 
     @Transactional
     public void addComment(Long postId, CommentAddRequest request, Long memberId) {
-        Member commentedMember = memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(ErrorCode.INVALID_USER_ID)
-        );
+        Member commentedMember = memberGetService.getMemberByIdOrThrow(memberId);
+
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new CustomException(ErrorCode.INVALID_POST)
         );
@@ -94,9 +93,7 @@ public class CommentService {
 
     @Transactional
     public void deleteComment(Long memberId, Long commentId, Long postId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(ErrorCode.INVALID_USER_ID)
-        );
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         Comment comment = commentDAO.findCommentByIdWithParent(commentId)
                 .orElseThrow(() -> new CustomException(INVALID_COMMENT));
         if (!comment.getMember().getId().equals(member.getId())) {

--- a/src/main/java/com/example/mdmggreal/image/service/ImageService.java
+++ b/src/main/java/com/example/mdmggreal/image/service/ImageService.java
@@ -1,9 +1,8 @@
 package com.example.mdmggreal.image.service;
 
-import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.image.dto.request.ImageDeleteRequest;
 import com.example.mdmggreal.member.entity.Member;
-import com.example.mdmggreal.member.repository.MemberRepository;
+import com.example.mdmggreal.member.service.MemberGetService;
 import com.example.mdmggreal.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,28 +12,20 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
-import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
-
 @RequiredArgsConstructor
 @Service
 @Slf4j
 public class ImageService {
     private final S3Service s3Service;
-    private final MemberRepository memberRepository;
+    private final MemberGetService memberGetService;
 
     public List<String> uploadImage(List<MultipartFile> multipartFile, Long memberId) throws IOException {
-        Member member = getMemberByMemberId(memberId);
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         return s3Service.uploadImages(multipartFile);
     }
 
     public void deleteImage(ImageDeleteRequest request, Long memberId) {
-        Member member = getMemberByMemberId(memberId);
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         s3Service.deleteImages(request);
-    }
-
-    private Member getMemberByMemberId(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(INVALID_USER_ID)
-        );
     }
 }

--- a/src/main/java/com/example/mdmggreal/member/service/MemberGetService.java
+++ b/src/main/java/com/example/mdmggreal/member/service/MemberGetService.java
@@ -1,0 +1,27 @@
+package com.example.mdmggreal.member.service;
+
+import com.example.mdmggreal.global.exception.CustomException;
+import com.example.mdmggreal.member.entity.Member;
+import com.example.mdmggreal.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
+
+@Service
+@RequiredArgsConstructor
+public class MemberGetService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 회원 id 로 Member 엔티티 조회, 없으면 Exception 발생
+     */
+    @Transactional(readOnly = true)
+    public Member getMemberByIdOrThrow(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(INVALID_USER_ID)
+        );
+    }
+}

--- a/src/main/java/com/example/mdmggreal/member/service/MyPageService.java
+++ b/src/main/java/com/example/mdmggreal/member/service/MyPageService.java
@@ -1,14 +1,12 @@
 package com.example.mdmggreal.member.service;
 
 import com.example.mdmggreal.common.dto.PageInfo;
-import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.member.dto.request.DeleteProfileRequest;
 import com.example.mdmggreal.member.dto.request.UpdateNickNameRequest;
 import com.example.mdmggreal.member.dto.response.MemberProfileDTO;
 import com.example.mdmggreal.member.dto.response.PostsByMemberGetResponse;
 import com.example.mdmggreal.member.dto.response.VotedPostsByMemberGetResponse;
 import com.example.mdmggreal.member.entity.Member;
-import com.example.mdmggreal.member.repository.MemberRepository;
 import com.example.mdmggreal.post.dto.vo.VotedPostVo;
 import com.example.mdmggreal.post.repository.PostQueryRepository;
 import com.example.mdmggreal.s3.service.S3Service;
@@ -25,7 +23,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_USER_ID;
 import static com.example.mdmggreal.post.entity.type.PostStatus.FINISHED;
 
 @RequiredArgsConstructor
@@ -33,13 +30,13 @@ import static com.example.mdmggreal.post.entity.type.PostStatus.FINISHED;
 public class MyPageService {
 
     private final PostQueryRepository postQueryRepository;
-    private final MemberRepository memberRepository;
     private final S3Service s3Service;
     private final VoteResultService voteResultService;
+    private final MemberGetService memberGetService;
 
     @Transactional(readOnly = true)
     public PostsByMemberGetResponse getPostsByMemberWithPagination(Long memberId, int pageNumber, int pageSize) {
-        getMemberByMemberId(memberId);
+        memberGetService.getMemberByIdOrThrow(memberId);
 
         Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
         Page<PostsByMemberGetResponse.MyPost> postsByMember = postQueryRepository.getPostsByMemberWithPagination(memberId, pageable);
@@ -49,25 +46,25 @@ public class MyPageService {
 
     @Transactional(readOnly = true)
     public MemberProfileDTO memberGet(Long memberId) {
-        Member member = getMemberByMemberId(memberId);
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         return MemberProfileDTO.from(member);
     }
 
     @Transactional
     public void updateNickName(UpdateNickNameRequest request) {
-        Member member = getMemberByMemberId(request.getMemberId());
+        Member member = memberGetService.getMemberByIdOrThrow(request.getMemberId());
         member.updateNickName(request.getNickName());
     }
 
     @Transactional
     public void deleteProfile(DeleteProfileRequest request) {
-        Member member = getMemberByMemberId(request.getMemberId());
+        Member member = memberGetService.getMemberByIdOrThrow(request.getMemberId());
         member.deleteProfile();
     }
 
     @Transactional(readOnly = true)
     public VotedPostsByMemberGetResponse getVotedPostsByMemberPagination(Long memberId, Pageable pageable) {
-        getMemberByMemberId(memberId);
+        memberGetService.getMemberByIdOrThrow(memberId);
 
         Page<VotedPostVo> votedPostVoList = postQueryRepository.getVotedPostsByMemberIdPagination(memberId, pageable);
         List<VotedPostsByMemberGetResponse.VotedPost> responseDtoList = new ArrayList<>();
@@ -81,24 +78,10 @@ public class MyPageService {
         return VotedPostsByMemberGetResponse.from(PageInfo.from(votedPostVoList), responseDtoList);
     }
 
-    /*
-     * 회원 조회.
-     *
-     * @param memberId 회원 id
-     * @return Member entity
-     */
-    private Member getMemberByMemberId(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(INVALID_USER_ID)
-        );
-    }
-
     @Transactional
     public void updateProfileImage(Long memberId, MultipartFile profileImage) throws IOException {
         String imageUrl = s3Service.uploadImages(profileImage);
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(INVALID_USER_ID)
-        );
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         member.updateProfile(imageUrl);
     }
 }

--- a/src/main/java/com/example/mdmggreal/post/service/PostService.java
+++ b/src/main/java/com/example/mdmggreal/post/service/PostService.java
@@ -11,7 +11,7 @@ import com.example.mdmggreal.ingameinfo.entity.InGameInfo;
 import com.example.mdmggreal.ingameinfo.repository.InGameInfoRepository;
 import com.example.mdmggreal.member.dto.MemberDTO;
 import com.example.mdmggreal.member.entity.Member;
-import com.example.mdmggreal.member.repository.MemberRepository;
+import com.example.mdmggreal.member.service.MemberGetService;
 import com.example.mdmggreal.post.dto.PostDTO;
 import com.example.mdmggreal.post.dto.request.PostAddRequest;
 import com.example.mdmggreal.post.entity.Post;
@@ -36,11 +36,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import static com.example.mdmggreal.global.exception.ErrorCode.*;
+import static com.example.mdmggreal.global.exception.ErrorCode.INVALID_END_DATE;
+import static com.example.mdmggreal.global.exception.ErrorCode.NO_PERMISSION_TO_DELETE_POST;
 import static java.math.BigDecimal.ZERO;
 
 @RequiredArgsConstructor
@@ -52,15 +52,15 @@ public class PostService {
     private final InGameInfoRepository inGameInfoRepository;
     private final PostHashtagRepository postHashtagRepository;
     private final HashtagQueryRepository hashtagQueryRepository;
-    private final MemberRepository memberRepository;
     private final PostQueryRepository postQueryRepository;
     private final VoteQueryRepository voteQueryRepository;
     private final HashtagRepository hashtagRepository;
     private final VoteRepository voteRepository;
+    private final MemberGetService memberGetService;
 
     @Transactional
     public void addPost(MultipartFile videoFile, MultipartFile thumbnailImage, PostAddRequest postAddRequest, String content, Long memberId) throws IOException {
-        Member member = getMemberByMemberId(memberId);
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
 
         LocalDateTime requestEndDateTime = validateAndConvertStringToDateTime(postAddRequest.voteEndDate());
 
@@ -109,7 +109,7 @@ public class PostService {
 
     @Transactional
     public void deletePost(Long postId, Long memberId) {
-        Member loginMember = getMemberByMemberId(memberId);
+        Member loginMember = memberGetService.getMemberByIdOrThrow(memberId);
         Post post = getPostById(postId);
 
         if (!post.getMember().getId().equals(loginMember.getId())) {
@@ -154,7 +154,7 @@ public class PostService {
     private PostDTO createPostDTO(Post post, Long memberId) {
         boolean isVote = false;
         if (memberId != null) {
-            Member loginMember = getMemberByMemberId(memberId);
+            Member loginMember = memberGetService.getMemberByIdOrThrow(memberId);
             isVote = voteQueryRepository.existsVoteByMemberId(post.getId(), loginMember.getId());
         }
 
@@ -199,9 +199,4 @@ public class PostService {
         return post;
     }
 
-    private Member getMemberByMemberId(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(INVALID_USER_ID)
-        );
-    }
 }

--- a/src/main/java/com/example/mdmggreal/vote/service/VoteService.java
+++ b/src/main/java/com/example/mdmggreal/vote/service/VoteService.java
@@ -5,7 +5,7 @@ import com.example.mdmggreal.global.exception.ErrorCode;
 import com.example.mdmggreal.ingameinfo.entity.InGameInfo;
 import com.example.mdmggreal.ingameinfo.repository.InGameInfoRepository;
 import com.example.mdmggreal.member.entity.Member;
-import com.example.mdmggreal.member.repository.MemberRepository;
+import com.example.mdmggreal.member.service.MemberGetService;
 import com.example.mdmggreal.member.type.MemberTier;
 import com.example.mdmggreal.post.entity.Post;
 import com.example.mdmggreal.post.entity.type.PostStatus;
@@ -28,16 +28,16 @@ import static com.example.mdmggreal.global.exception.ErrorCode.*;
 @RequiredArgsConstructor
 public class VoteService {
 
-    private final MemberRepository memberRepository;
     private final VoteRepository voteRepository;
     private final VoteQueryRepository voteQueryRepository;
     private final InGameInfoRepository inGameInfoRepository;
     private final PostRepository postRepository;
+    private final MemberGetService memberGetService;
 
     @Transactional
     public void addVotes(VoteAddRequest request, Long memberId, Long postId) {
         List<VoteAddDTO> voteAddDTOList = request.getVoteList();
-        Member member = getMemberById(memberId);
+        Member member = memberGetService.getMemberByIdOrThrow(memberId);
         List<InGameInfo> inGameInfoList = inGameInfoRepository.findByPostId(postId);
 
         // 클라이언트 요청 검증
@@ -115,12 +115,6 @@ public class VoteService {
         if (!member.getMemberTier().equals(memberTier)) {
             member.updateTier(memberTier);
         }
-    }
-
-    private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(INVALID_USER_ID)
-        );
     }
 
     private void rewardPoint(Member member) {


### PR DESCRIPTION
- 기존에 memberEntity를 직접 조회하던 서비스들이 해당 서비스를 통해 회원 조회하도록 수정

### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
- 회원 entity 조회가 필요한 서비스에서, memberRepository에서 각각 메서드 호출하고 있었음. 회원서비스가 아닌데 불필요한 회원관련 메서드 존재하게 됨.

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
- MemberGetService 파일 생성, 회원 id로 조회하고 없으면 exception 발생시키는 메서드 생성하여 타 서비스에서 이를 호출하도록 수정
  - 회원 서비스가 아닌 곳에서 회원을 조회하기 위해 memberRepository에 직접 접근하는 것을 방지 -> 유지보수성 향상
  - 중복 코드 제거
  - 코드의 길이가 짧아져 가독성 향상

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요