### PR TITLE
Feat: 댓글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
+++ b/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
@@ -39,12 +39,15 @@ public class CommentController {
         return ResponseEntity.ok(CommentGetListResponse.from(commentList, OK));
     }
 
+    /**
+     * 댓글 삭제
+     */
     @DeleteMapping("/{commentid}")
     public ResponseEntity<BaseResponse> commentDelete(@RequestHeader(value = "Authorization") String token,
                                                       @PathVariable(value = "postid") Long postId,
                                                       @PathVariable(value = "commentid") Long commentId) {
         Long memberId = JwtUtil.getMemberId(token);
-        commentService.deleteComment(memberId, commentId, postId);
+        commentService.deleteComment(memberId, commentId);
         return BaseResponse.toResponseEntity(OK);
     }
 

--- a/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
+++ b/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
@@ -16,16 +16,16 @@ import java.util.List;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-@RequestMapping("/api/post/{postid}/comment")
+@RequestMapping("/api/comment")
 @RequiredArgsConstructor
 @RestController
 public class CommentController {
     private final CommentService commentService;
 
 
-    @PostMapping
+    @PostMapping("/post/{postId}")
     public ResponseEntity<BaseResponse> commentAdd(@RequestHeader(value = "Authorization") String token,
-                                                   @PathVariable(value = "postid") Long postId,
+                                                   @PathVariable(value = "postId") Long postId,
                                                    @RequestBody @Valid CommentAddRequest request
     ) {
         Long memberId = JwtUtil.getMemberId(token);
@@ -34,7 +34,7 @@ public class CommentController {
     }
 
     @GetMapping
-    public ResponseEntity<CommentGetListResponse> commentGetList(@PathVariable(value = "postid") Long postId) {
+    public ResponseEntity<CommentGetListResponse> commentGetList(@RequestParam(value = "postid") Long postId) {
         List<CommentDTO> commentList = commentService.getCommentList(postId);
         return ResponseEntity.ok(CommentGetListResponse.from(commentList, OK));
     }
@@ -42,10 +42,9 @@ public class CommentController {
     /**
      * 댓글 삭제
      */
-    @DeleteMapping("/{commentid}")
+    @DeleteMapping("/{commentId}")
     public ResponseEntity<BaseResponse> commentDelete(@RequestHeader(value = "Authorization") String token,
-                                                      @PathVariable(value = "postid") Long postId,
-                                                      @PathVariable(value = "commentid") Long commentId) {
+                                                      @PathVariable(value = "commentId") Long commentId) {
         Long memberId = JwtUtil.getMemberId(token);
         commentService.deleteComment(memberId, commentId);
         return BaseResponse.toResponseEntity(OK);

--- a/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
+++ b/src/main/java/com/example/mdmggreal/comment/controller/CommentController.java
@@ -16,14 +16,14 @@ import java.util.List;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-@RequestMapping("/api/comment")
+//@RequestMapping("/api/comment")
 @RequiredArgsConstructor
 @RestController
 public class CommentController {
     private final CommentService commentService;
 
 
-    @PostMapping("/post/{postId}")
+    @PostMapping("/api/post/{postId}/comment")
     public ResponseEntity<BaseResponse> commentAdd(@RequestHeader(value = "Authorization") String token,
                                                    @PathVariable(value = "postId") Long postId,
                                                    @RequestBody @Valid CommentAddRequest request
@@ -33,8 +33,8 @@ public class CommentController {
         return BaseResponse.toResponseEntity(CREATED);
     }
 
-    @GetMapping
-    public ResponseEntity<CommentGetListResponse> commentGetList(@RequestParam(value = "postid") Long postId) {
+    @GetMapping("/api/post/{postId}/comment")
+    public ResponseEntity<CommentGetListResponse> commentGetList(@PathVariable(value = "postId") Long postId) {
         List<CommentDTO> commentList = commentService.getCommentList(postId);
         return ResponseEntity.ok(CommentGetListResponse.from(commentList, OK));
     }
@@ -42,7 +42,7 @@ public class CommentController {
     /**
      * 댓글 삭제
      */
-    @DeleteMapping("/{commentId}")
+    @DeleteMapping("/api/comment/{commentId}")
     public ResponseEntity<BaseResponse> commentDelete(@RequestHeader(value = "Authorization") String token,
                                                       @PathVariable(value = "commentId") Long commentId) {
         Long memberId = JwtUtil.getMemberId(token);

--- a/src/main/java/com/example/mdmggreal/comment/entity/Comment.java
+++ b/src/main/java/com/example/mdmggreal/comment/entity/Comment.java
@@ -75,7 +75,7 @@ public class Comment extends BaseEntity {
                 .build();
     }
 
-    public void changeIsDeleted(Boolean isDeleted) {
+    public void changeIsDeleted(boolean isDeleted) {
         this.isDeleted = isDeleted ? TRUE : FALSE;
     }
 }

--- a/src/main/java/com/example/mdmggreal/comment/repository/CommentQueryRepository.java
+++ b/src/main/java/com/example/mdmggreal/comment/repository/CommentQueryRepository.java
@@ -2,7 +2,6 @@ package com.example.mdmggreal.comment.repository;
 
 import com.example.mdmggreal.comment.entity.Comment;
 import com.example.mdmggreal.comment.entity.QComment;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
@@ -13,14 +12,11 @@ import static com.example.mdmggreal.comment.entity.QComment.comment;
 import static com.example.mdmggreal.post.entity.QPost.post;
 
 @Repository
-public class CommentDAO extends QuerydslRepositorySupport {
-    private final JPAQueryFactory jpaQueryFactory;
+public class CommentQueryRepository extends QuerydslRepositorySupport {
 
-    public CommentDAO(JPAQueryFactory jpaQueryFactory) {
-        super(CommentDAO.class);
-        this.jpaQueryFactory = jpaQueryFactory;
+    public CommentQueryRepository() {
+        super(Comment.class);
     }
-
 
     public List<Comment> getList(Long postId) {
         return from(comment)
@@ -39,6 +35,5 @@ public class CommentDAO extends QuerydslRepositorySupport {
                 .where(QComment.comment.id.eq(commentId))
                 .fetchOne();
         return Optional.of(comment);
-
     }
 }

--- a/src/main/java/com/example/mdmggreal/comment/repository/CommentQueryRepository.java
+++ b/src/main/java/com/example/mdmggreal/comment/repository/CommentQueryRepository.java
@@ -1,12 +1,10 @@
 package com.example.mdmggreal.comment.repository;
 
 import com.example.mdmggreal.comment.entity.Comment;
-import com.example.mdmggreal.comment.entity.QComment;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.example.mdmggreal.comment.entity.QComment.comment;
 import static com.example.mdmggreal.post.entity.QPost.post;
@@ -29,11 +27,4 @@ public class CommentQueryRepository extends QuerydslRepositorySupport {
 
     }
 
-    public Optional<Comment> findCommentByIdWithParent(Long commentId) {
-        Comment comment = from(QComment.comment)
-                .leftJoin(QComment.comment.parent).fetchJoin()
-                .where(QComment.comment.id.eq(commentId))
-                .fetchOne();
-        return Optional.of(comment);
-    }
 }

--- a/src/main/java/com/example/mdmggreal/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/mdmggreal/comment/repository/CommentRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -20,4 +21,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     long countDistinctPostsWithCommentsByMemberAndDate(@Param("memberId") Long memberId,
                                                        @Param("startOfDay") LocalDateTime startOfDay,
                                                        @Param("endOfDay") LocalDateTime endOfDay);
+
+    /*
+    특정 댓글의 대댓글 조회
+     */
+    List<Comment> findByParentId(Long parentId);
 }

--- a/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
+++ b/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
@@ -4,7 +4,7 @@ import com.example.mdmggreal.alarm.service.CommentAlarmService;
 import com.example.mdmggreal.comment.dto.CommentDTO;
 import com.example.mdmggreal.comment.dto.request.CommentAddRequest;
 import com.example.mdmggreal.comment.entity.Comment;
-import com.example.mdmggreal.comment.repository.CommentDAO;
+import com.example.mdmggreal.comment.repository.CommentQueryRepository;
 import com.example.mdmggreal.comment.repository.CommentRepository;
 import com.example.mdmggreal.global.exception.CustomException;
 import com.example.mdmggreal.global.exception.ErrorCode;
@@ -33,7 +33,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
-    private final CommentDAO commentDAO;
+    private final CommentQueryRepository commentQueryRepository;
     private final CommentAlarmService commentAlarmService;
 
     @Transactional
@@ -78,7 +78,7 @@ public class CommentService {
 
     @Transactional
     public List<CommentDTO> getCommentList(Long postId) {
-        List<Comment> list = commentDAO.getList(postId);
+        List<Comment> list = commentQueryRepository.getList(postId);
         List<CommentDTO> commentResponseDTOList = new ArrayList<>();
         Map<Long, CommentDTO> commentDTOHashMap = new HashMap<>();
 
@@ -97,7 +97,7 @@ public class CommentService {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new CustomException(ErrorCode.INVALID_USER_ID)
         );
-        Comment comment = commentDAO.findCommentByIdWithParent(commentId)
+        Comment comment = commentQueryRepository.findCommentByIdWithParent(commentId)
                 .orElseThrow(() -> new CustomException(INVALID_COMMENT));
         if (!comment.getMember().getId().equals(member.getId())) {
             throw new CustomException(ErrorCode.NO_PERMISSION_TO_DELETE_COMMENT);

--- a/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
+++ b/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
@@ -97,11 +97,9 @@ public class CommentService {
      */
     @Transactional
     public void deleteComment(Long memberId, Long commentId) {
-        Member member = memberGetService.getMemberByIdOrThrow(memberId);
-        Comment comment = commentQueryRepository.findCommentByIdWithParent(commentId)
-                .orElseThrow(() -> new CustomException(COMMENT_NOT_EXISTS));
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(COMMENT_NOT_EXISTS));
 
-        if (!comment.getMember().getId().equals(member.getId())) {
+        if (!memberId.equals(comment.getMember().getId())) {
             throw new CustomException(ErrorCode.NO_PERMISSION_TO_DELETE_COMMENT);
         }
 

--- a/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
+++ b/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
@@ -93,7 +93,7 @@ public class CommentService {
     }
 
     @Transactional
-    public void deleteComment(Long memberId, Long commentId, Long postId) {
+    public void deleteComment(Long memberId, Long commentId) {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new CustomException(ErrorCode.INVALID_USER_ID)
         );
@@ -102,23 +102,8 @@ public class CommentService {
         if (!comment.getMember().getId().equals(member.getId())) {
             throw new CustomException(ErrorCode.NO_PERMISSION_TO_DELETE_COMMENT);
         }
-        comment.changeIsDeleted(TRUE);
-        /*
-        todo 1.댓글 삭제시 포인트 롤백정책 정해질 경우 로직구현
-         */
-//        validateRollbackPoint(postId, memberId);
+        comment.changeIsDeleted(true);
     }
-
-//    private void validateRollbackPoint(Long postId, Long memberId) {
-//        boolean isCommentAuthor = commentRepository.existsByPostIdAndMemberId(postId, memberId);
-//        if (!isCommentAuthor) {
-//            rollbackPoint(postId, memberId);
-//        }
-//    }
-//
-//    private void rollbackPoint(Long postId, Long memberId) {
-//
-//    }
 
     private void rewardPoint(Long postId, Member commentedMember) {
         Long commentedMemberId = commentedMember.getId();

--- a/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
+++ b/src/main/java/com/example/mdmggreal/comment/service/CommentService.java
@@ -32,7 +32,6 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
-    private final MemberRepository memberRepository;
     private final CommentQueryRepository commentQueryRepository;
     private final CommentAlarmService commentAlarmService;
     private final MemberGetService memberGetService;
@@ -93,7 +92,7 @@ public class CommentService {
     }
 
     @Transactional
-    public void deleteComment(Long memberId, Long commentId, Long postId) {
+    public void deleteComment(Long memberId, Long commentId) {
         Member member = memberGetService.getMemberByIdOrThrow(memberId);
         Comment comment = commentQueryRepository.findCommentByIdWithParent(commentId)
                 .orElseThrow(() -> new CustomException(INVALID_COMMENT));

--- a/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mdmggreal/global/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     COMMENT_NOT_EXISTS(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다"),
     INVALID_PARENT_ID(HttpStatus.BAD_REQUEST, "postId에 맞는 parentId인지 확인해주세요."),
     NO_PERMISSION_TO_DELETE_COMMENT(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    CANNOT_DELETE_COMMENT_WITH_CHILD(HttpStatus.UNAUTHORIZED, "대댓글이 있는 댓글은 삭제할 수 없습니다."),
 
     // 해시태그
     HASHTAGNAME_NOT_MATCH(HttpStatus.BAD_REQUEST, "해시태그 이름이 일치하지 않습니다."),


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 댓글 삭제기능 추가 필요
2. 쿼리dsl 사용하는 Repository 명칭 통일 필요 (000QueryRepository)

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. 댓글 삭제기능 추가
  - 기존에 임시로 있었던 댓글 삭제기능은 무시
  - 대댓글이 있는 경우 삭제 불가능 처리
2. CommentDAO 명칭 수정 -> CommentQueryRepository 

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요

1. 추가로, Comment Entity의 삭제여부 수정 메서드가 Wrapper Boolean 타입을 받을 필요가 없어서, 타입 수정함. 가독성 향상 위함.
