### PR TITLE
Fix: 게시글 목록/상세 조회 시 프로필 url 안나옴

### DIFF
--- a/src/main/java/com/example/mdmggreal/member/dto/MemberDTO.java
+++ b/src/main/java/com/example/mdmggreal/member/dto/MemberDTO.java
@@ -41,6 +41,7 @@ public class MemberDTO  {
                 .nickname(member.getNickname())
                 .email(member.getEmail())
                 .mobile(member.getMobile())
+                .profileImage(member.getProfileImage())
                 .tier(member.getMemberTier().getName())
                 .predictedResult(member.getPredictedResult())
                 .joinedResult(member.getJoinedResult())


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
- 프로필 url 안나오는 부분 발견

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
- 프로필 url 나오도록 수정. memberDTO 빌더에 없었음. 추가함.

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
