### PR TITLE
Fix: 댓글 목록 조회 시 삭제된 댓글 필터링

### DIFF
--- a/src/main/java/com/example/mdmggreal/comment/dto/response/CommentGetListResponse.java
+++ b/src/main/java/com/example/mdmggreal/comment/dto/response/CommentGetListResponse.java
@@ -44,7 +44,7 @@ public class CommentGetListResponse extends BaseResponse {
         public static CommentDTO from(Comment comment) {
             return CommentDTO.builder()
                     .id(comment.getId())
-                    .content(comment.getIsDeleted().equals(TRUE) ? "삭제된 댓글입니다." : comment.getContent())
+                    .content(comment.getContent())
                     .member(MemberDTO.from(comment.getMember()))
                     .parentMemberNickname(comment.getParent() == null ? null : comment.getParent().getMember().getNickname())
                     .createdDateTime(comment.getCreatedDateTime())

--- a/src/main/java/com/example/mdmggreal/comment/repository/CommentQueryRepository.java
+++ b/src/main/java/com/example/mdmggreal/comment/repository/CommentQueryRepository.java
@@ -2,6 +2,7 @@ package com.example.mdmggreal.comment.repository;
 
 import com.example.mdmggreal.comment.entity.Comment;
 import com.example.mdmggreal.comment.entity.QComment;
+import com.example.mdmggreal.global.entity.type.BooleanEnum;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -42,7 +43,8 @@ public class CommentQueryRepository extends QuerydslRepositorySupport {
         );
 
         return from(comment)
-                .where(comment.post.id.eq(postId))
+                .where(comment.post.id.eq(postId)
+                        .and(comment.isDeleted.eq(BooleanEnum.FALSE)))
                 .orderBy(orderByParentNull, orderByParentNotNull)
                 .fetch();
     }


### PR DESCRIPTION
### AS - IS
☝️ 변경 전의 상태, 상황, 문제점, 왜 수정했는지 등을 기술해주세요.
1. 삭제된 댓글을 UI에서 없애는 방향으로 정책 수정

---
### TO - BE
☝️ 변경 후의 상태, 어떻게 수정했는지 등을 기술해주세요.
1. 삭제된 댓글 조회 안되도록 쿼리 수정

---
### 추후 수정사항, 공유할 내용, 기타
☝️ 자유롭게 기술해주세요
